### PR TITLE
Code cleanup and handling of number of records returned

### DIFF
--- a/astroquery/eso/__init__.py
+++ b/astroquery/eso/__init__.py
@@ -18,7 +18,7 @@ class Conf(_config.ConfigNamespace):
         "",
         'Optional default username for ESO archive.')
     tap_url = _config.ConfigItem(
-        "http://archive.eso.org/tap_obs",
+        "https://archive.eso.org/tap_obs",
         'URL for TAP queries.')
     tap_url_dev = _config.ConfigItem(
         os.environ['TAP_URL_DEV'],

--- a/astroquery/eso/__init__.py
+++ b/astroquery/eso/__init__.py
@@ -3,6 +3,7 @@
 ESO service.
 """
 from astropy import config as _config
+import os
 
 
 class Conf(_config.ConfigNamespace):
@@ -16,10 +17,12 @@ class Conf(_config.ConfigNamespace):
     username = _config.ConfigItem(
         "",
         'Optional default username for ESO archive.')
-    query_instrument_url = _config.ConfigItem(
-        "http://archive.eso.org/wdb/wdb/eso",
-        'Root query URL for main and instrument queries.')
-
+    tap_url = _config.ConfigItem(
+        "http://archive.eso.org/tap_obs",
+        'URL for TAP queries.')
+    tap_url_dev = _config.ConfigItem(
+        os.environ['TAP_URL_DEV'],
+        'URL for TAP development server.')
 
 conf = Conf()
 

--- a/astroquery/eso/__init__.py
+++ b/astroquery/eso/__init__.py
@@ -3,7 +3,6 @@
 ESO service.
 """
 from astropy import config as _config
-import os
 
 
 class Conf(_config.ConfigNamespace):
@@ -20,9 +19,7 @@ class Conf(_config.ConfigNamespace):
     tap_url = _config.ConfigItem(
         "https://archive.eso.org/tap_obs",
         'URL for TAP queries.')
-    tap_url_dev = _config.ConfigItem(
-        os.environ['TAP_URL_DEV'],
-        'URL for TAP development server.')
+
 
 conf = Conf()
 

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -11,6 +11,7 @@ European Southern Observatory (ESO)
 import base64
 import email
 import json
+import os
 import os.path
 import pickle
 import re
@@ -109,7 +110,14 @@ class EsoClass(QueryWithLogin):
     def tap_url() -> str:
         url = conf.tap_url
         if EsoClass.USE_DEV_TAP:
-            url = conf.tap_url_dev
+            try:
+                url = os.environ['TAP_URL']
+            except KeyError as e:
+                raise EnvironmentError(
+                    "Running on dev mode, but TAP_URL environment variable is not set"
+                ) from e
+            logmsg = f"Using dev tap url: {url}"
+            log.info(logmsg)
         return url
 
     def request_file(self, query_str: str):

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -282,7 +282,8 @@ class EsoClass(QueryWithLogin):
             warnings.warn("Query returned no results", NoResultsWarning)
 
         if len(table_to_return) == maxrec:
-            warnings.warn(f"Results truncated to {maxrec}", MaxResultsWarning)
+            warnings.warn(f"Results truncated to {maxrec}. "
+                          "To retrieve all the records set to None the ROW_LIMIT attribute", MaxResultsWarning)
 
         return table_to_return
 

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -253,12 +253,12 @@ class EsoClass(QueryWithLogin):
         except pyvo.dal.exceptions.DALQueryError as e:
             raise pyvo.dal.exceptions.DALQueryError(f"\n\n\
                             Error executing the following query:\n\n{query_str}\n\n\
-                            See examples here: http://archive.eso.org/tap_obs/examples\n\n") from e
+                            See examples here: https://archive.eso.org/tap_obs/examples\n\n") from e
         except Exception as e:
             raise RuntimeError(f"\n\n\
                             Unknown exception {e} while executing the\
                             following query: \n\n{query_str}\n\n\
-                            See examples here: http://archive.eso.org/tap_obs/examples\n\n") from e
+                            See examples here: https://archive.eso.org/tap_obs/examples\n\n") from e
 
         if len(table_to_return) < 1:
             warnings.warn("Query returned no results", NoResultsWarning)
@@ -443,7 +443,7 @@ class EsoClass(QueryWithLogin):
         result = []
         for dp_id in product_ids:
             response = self._request(
-                "GET", f"http://archive.eso.org/hdr?DpId={dp_id}",
+                "GET", f"https://archive.eso.org/hdr?DpId={dp_id}",
                 cache=cache)
             root = BeautifulSoup(response.content, 'html5lib')
             hdr = root.select('pre')[0].text
@@ -500,7 +500,8 @@ class EsoClass(QueryWithLogin):
             files_to_check.append(filename.rsplit(".", 1)[0])
         for file in files_to_check:
             if os.path.exists(file):
-                EsoClass.log_info(f"Found cached file {file}")
+                logmsg = (f"Found cached file {file}")
+                log.info(logmsg)
                 return True
         return False
 

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -20,7 +20,6 @@ import time
 import warnings
 import xml.etree.ElementTree as ET
 from typing import List, Optional, Tuple, Dict, Set, Union
-from dataclasses import dataclass
 from datetime import datetime, timezone, timedelta
 
 import astropy.table
@@ -29,7 +28,7 @@ import astropy.units as u
 import keyring
 import requests.exceptions
 from astropy.table import Table, Column
-from astropy.utils.decorators import deprecated, deprecated_renamed_argument
+from astropy.utils.decorators import deprecated_renamed_argument
 from bs4 import BeautifulSoup
 import pyvo
 
@@ -67,20 +66,15 @@ class AuthInfo:
         return time.time() > self.expiration_time - 600
 
 
-@dataclass
-class QueryOnField:
-    table_name: str
-    column_name: str
+class EsoNames:
+    raw_table = "dbo.raw"
+    phase3_table = "ivoa.ObsCore"
+    raw_instruments_column = "instrument"
+    phase3_collections_column = "obs_collection"
 
-
-QueryOnInstrument = QueryOnField(
-    table_name="dbo.raw",  # This should be ist.<instrument_name>
-    column_name="instrument")
-
-
-QueryOnCollection = QueryOnField(
-    table_name="ivoa.ObsCore",
-    column_name="obs_collection")
+    @staticmethod
+    def ist_table(instrument_name):
+        return f"ist.{instrument_name}"
 
 
 class EsoClass(QueryWithLogin):
@@ -104,10 +98,6 @@ class EsoClass(QueryWithLogin):
     def timeout(self):
         return self._timeout
 
-    # The logging module needs strings
-    # written in %s style. This wrappers
-    # are used for that purpose.
-    # [W1203 - logging-fstring-interpolation]
     @staticmethod
     def log_info(message):
         "Wrapper for logging function"
@@ -321,8 +311,8 @@ class EsoClass(QueryWithLogin):
         """
         if self._collections is None:
             self._collections = []
-            c = QueryOnCollection.column_name
-            t = QueryOnCollection.table_name
+            t = EsoNames.phase3_table
+            c = EsoNames.phase3_collections_column
             query_str = f"select distinct {c} from {t}"
             res = self.query_tap_service(query_str, cache=cache)[c].data
 
@@ -343,30 +333,29 @@ class EsoClass(QueryWithLogin):
         self.log_info(f"\nColumns present in the table {table_name}:\n{available_cols}\n")
         astropy.conf.max_lines = n_
 
-    def _query_instrument_or_collection(self,
-                                        query_on: QueryOnField,
-                                        collections: Union[List[str], str], *,
-                                        ra: float = None, dec: float = None, radius: float = None,
-                                        column_filters: Dict = None,
-                                        columns: Union[List, str] = None,
-                                        print_help=False, cache=True,
-                                        **kwargs) -> astropy.table.Table:
+    def _query_on_allowed_values(self,
+                                 table_name: str,
+                                 column_name: str,
+                                 allowed_values: Union[List[str], str] = None, *,
+                                 ra: float = None, dec: float = None, radius: float = None,
+                                 columns: Union[List, str] = None,
+                                 print_help=False, cache=True,
+                                 **kwargs) -> astropy.table.Table:
         """
         Query instrument- or collection-specific data contained in the ESO archive.
          - instrument-specific data is raw
          - collection-specific data is processed
         """
-        column_filters = column_filters or {}
         columns = columns or []
-        filters = {**dict(kwargs), **column_filters}
+        filters = {**dict(kwargs)}
 
         if print_help:
-            self.print_table_help(query_on.table_name)
+            self.print_table_help(table_name)
             return
 
-        if (('box' in filters.keys())
-            or ('coord1' in filters.keys())
-                or ('coord2' in filters.keys())):
+        if (('box' in filters)
+            or ('coord1' in filters)
+                or ('coord2' in filters)):
             message = 'box, coord1 and coord2 are deprecated; use ra, dec and radius instead'
             raise ValueError(message)
 
@@ -375,125 +364,67 @@ class EsoClass(QueryWithLogin):
             message += f"Values provided: ra = {ra}, dec = {dec}, radius = {radius}"
             raise ValueError(message)
 
-        if isinstance(collections, str):
-            collections = _split_str_as_list_of_str(collections)
+        where_collections_strlist = []
+        if allowed_values:
+            if isinstance(allowed_values, str):
+                allowed_values = _split_str_as_list_of_str(allowed_values)
 
-        collections = list(map(lambda x: f"'{x.strip()}'", collections))
-        where_collections_str = f"{query_on.column_name} in (" + ", ".join(collections) + ")"
+            allowed_values = list(map(lambda x: f"'{x.strip()}'", allowed_values))
+            where_collections_strlist = [f"{column_name} in (" + ", ".join(allowed_values) + ")"]
 
         where_constraints_strlist = [f"{k} = {adql_sanitize_val(v)}" for k, v in filters.items()]
-        where_constraints = [where_collections_str] + where_constraints_strlist
-        query = py2adql(table=query_on.table_name, columns=columns,
+        where_constraints = where_collections_strlist + where_constraints_strlist
+        query = py2adql(table=table_name, columns=columns,
                         ra=ra, dec=dec, radius=radius,
                         where_constraints=where_constraints,
                         top=self.ROW_LIMIT)
 
         return self.query_tap_service(query_str=query, cache=cache)
 
-    @deprecated_renamed_argument(('open_form', 'help'), (None, 'print_help'),
-                                 since=['0.4.8', '0.4.8'])
-    def query_instrument(self, instrument: Union[List, str] = None, *,
-                         ra: float = None, dec: float = None, radius: float = None,
-                         column_filters: Dict = None, columns: Union[List, str] = None,
-                         open_form=False, print_help=False, cache=True,
-                         **kwargs) -> astropy.table.Table:
-        _ = open_form
-        return self._query_instrument_or_collection(query_on=QueryOnInstrument,
-                                                    collections=instrument,
-                                                    ra=ra, dec=dec, radius=radius,
-                                                    column_filters=column_filters,
-                                                    columns=columns,
-                                                    print_help=print_help,
-                                                    cache=cache,
-                                                    **kwargs)
-
-    @deprecated_renamed_argument(('open_form', 'help'), (None, 'print_help'),
-                                 since=['0.4.8', '0.4.8'])
-    def query_collections(self, collections: Union[List, str] = None, *,
+    # ex query_collections
+    def query_collections(self,
+                          collections: Union[List[str], str], *,
                           ra: float = None, dec: float = None, radius: float = None,
-                          column_filters: Dict = None, columns: Union[List, str] = None,
-                          open_form=False, print_help=False, cache=True,
+                          columns: Union[List, str] = None,
+                          print_help=False, cache=True,
                           **kwargs) -> astropy.table.Table:
-        column_filters = column_filters or {}
-        columns = columns or []
-        _ = open_form
-        return self._query_instrument_or_collection(query_on=QueryOnCollection,
-                                                    collections=collections,
-                                                    ra=ra, dec=dec, radius=radius,
-                                                    column_filters=column_filters,
-                                                    columns=columns,
-                                                    print_help=print_help,
-                                                    cache=cache,
-                                                    **kwargs)
+        return self._query_on_allowed_values(table_name=EsoNames.phase3_table,
+                                             column_name=EsoNames.phase3_collections_column,
+                                             allowed_values=collections,
+                                             ra=ra, dec=dec, radius=radius,
+                                             columns=columns,
+                                             print_help=print_help, cache=cache,
+                                             **kwargs)
 
-    @deprecated_renamed_argument(old_name='help', new_name='print_help', since='0.4.8')
-    def query_raw(self, *,
-                  ra: float = None, dec: float = None, radius: float = None,
-                  column_filters=None, columns=None,
-                  print_help=False, cache=True, **kwargs):
-        """
-        Query raw data contained in the ESO archive.
-
-        Returns
-        -------
-        table : `~astropy.table.Table`, the number of rows
-        capped by the ROW_LIMIT configuration item.
-        """
-        column_filters = column_filters or {}
-        columns = columns or []
-        filters = {**dict(kwargs), **column_filters}
-        table_name = "dbo.raw"
-
-        if print_help:
-            self.print_table_help(table_name=table_name)
-            return
-
-        where_constraints_strlist = [f"{k} = {adql_sanitize_val(v)}" for k, v in filters.items()]
-        where_constraints = where_constraints_strlist
-
-
-        query = py2adql(table=table_name,
-                        columns=columns,
-                        ra=ra, dec=dec, radius=radius,
-                        where_constraints=where_constraints,
-                        top=self.ROW_LIMIT)
-
-        return self.query_tap_service(query_str=query, cache=cache)
-
-    @deprecated_renamed_argument(old_name='help', new_name='print_help', since='0.4.8')
-    def query_prods(self, *,
+    # ex query_main
+    def query_main(self,
+                   instruments: Union[List[str], str] = None, *,
                    ra: float = None, dec: float = None, radius: float = None,
-                   column_filters=None, columns=None,
-                   print_help=False, cache=True, **kwargs):
-        """
-        Query processed data contained in the ESO archive.
+                   columns: Union[List, str] = None,
+                   print_help=False, cache=True,
+                   **kwargs) -> astropy.table.Table:
+        return self._query_on_allowed_values(table_name=EsoNames.raw_table,
+                                             column_name=EsoNames.raw_instruments_column,
+                                             allowed_values=instruments,
+                                             ra=ra, dec=dec, radius=radius,
+                                             columns=columns,
+                                             print_help=print_help, cache=cache,
+                                             **kwargs)
 
-        Returns
-        -------
-        table : `~astropy.table.Table`, the number of rows
-        capped by the ROW_LIMIT configuration item.
-        """
-        column_filters = column_filters or {}
-        columns = columns or []
-        filters = {**dict(kwargs), **column_filters}
-
-        where_constraints_strlist = [f"{k} = {adql_sanitize_val(v)}" for k, v in filters.items()]
-        where_constraints = where_constraints_strlist
-
-        if print_help:
-            help_query = \
-                "select column_name, datatype from TAP_SCHEMA.columns where table_name = 'ivoa.ObsCore'"
-            h = self.query_tap_service(help_query, cache=cache)
-            self.log_info(f"Columns present in the table: {h}")
-            return
-
-        query = py2adql(table="ivoa.ObsCore",
-                        columns=columns,
-                        ra=ra, dec=dec, radius=radius,
-                        where_constraints=where_constraints,
-                        top=self.ROW_LIMIT)
-
-        return self.query_tap_service(query_str=query, cache=cache)
+    # ex query_instrument
+    def query_instrument(self,
+                         instrument: str, *,
+                         ra: float = None, dec: float = None, radius: float = None,
+                         columns: Union[List, str] = None,
+                         print_help=False, cache=True,
+                         **kwargs) -> astropy.table.Table:
+        return self._query_on_allowed_values(table_name=EsoNames.ist_table(instrument),
+                                             column_name=None,
+                                             allowed_values=None,
+                                             ra=ra, dec=dec, radius=radius,
+                                             columns=columns,
+                                             print_help=print_help, cache=cache,
+                                             **kwargs)
 
     def get_headers(self, product_ids, *, cache=True):
         """
@@ -820,22 +751,6 @@ class EsoClass(QueryWithLogin):
             return self.query_tap_service(query_str=query, cache=cache)
         else:
             raise NotImplementedError
-
-    @deprecated(since="v0.4.8", message=("The ESO list_surveys function is deprecated,"
-                                         "Use the list_collections  function instead."))
-    def list_surveys(self, *args, **kwargs):
-        if "surveys" in kwargs:
-            kwargs["collections"] = kwargs["surveys"]
-            del kwargs["surveys"]
-        return self.list_collections(*args, **kwargs)
-
-    @deprecated(since="v0.4.8", message=("The ESO query_surveys function is deprecated,"
-                                         "Use the query_collections  function instead."))
-    def query_surveys(self, *args, **kwargs):
-        if "surveys" in kwargs:
-            kwargs["collections"] = kwargs["surveys"]
-            del kwargs["surveys"]
-        return self.query_collections(*args, **kwargs)
 
 
 Eso = EsoClass()

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -381,7 +381,6 @@ class EsoClass(QueryWithLogin):
 
         return self.query_tap_service(query_str=query, cache=cache)
 
-    # ex query_collections
     def query_collections(self,
                           collections: Union[List[str], str], *,
                           ra: float = None, dec: float = None, radius: float = None,
@@ -396,7 +395,6 @@ class EsoClass(QueryWithLogin):
                                              print_help=print_help, cache=cache,
                                              **kwargs)
 
-    # ex query_main
     def query_main(self,
                    instruments: Union[List[str], str] = None, *,
                    ra: float = None, dec: float = None, radius: float = None,

--- a/astroquery/eso/tests/test_eso.py
+++ b/astroquery/eso/tests/test_eso.py
@@ -110,7 +110,7 @@ def test_main_SgrAstar(monkeypatch):
     # monkeypatch instructions from https://pytest.org/latest/monkeypatch.html
     eso = Eso()
     monkeypatch.setattr(eso, 'query_tap_service', monkey_tap)
-    result = eso.query_raw(target='SGR A', object='SGR A')
+    result = eso.query_main(target='SGR A', object='SGR A')
     # test all results are there and the expected target is present
     assert len(result) == 23
     assert 'SGR A' in result['object']

--- a/astroquery/eso/tests/test_eso.py
+++ b/astroquery/eso/tests/test_eso.py
@@ -110,7 +110,7 @@ def test_main_SgrAstar(monkeypatch):
     # monkeypatch instructions from https://pytest.org/latest/monkeypatch.html
     eso = Eso()
     monkeypatch.setattr(eso, 'query_tap_service', monkey_tap)
-    result = eso.query_main(target='SGR A', object='SGR A')
+    result = eso.query_raw(target='SGR A', object='SGR A')
     # test all results are there and the expected target is present
     assert len(result) == 23
     assert 'SGR A' in result['object']

--- a/astroquery/eso/tests/test_eso.py
+++ b/astroquery/eso/tests/test_eso.py
@@ -32,9 +32,9 @@ DATA_FILES = {
         },
     'POST':
         {
-            'http://archive.eso.org/wdb/wdb/eso/eso_archive_main/query': 'main_sgra_query.tbl',
-            'http://archive.eso.org/wdb/wdb/eso/amber/query': 'amber_sgra_query.tbl',
-            'http://archive.eso.org/wdb/wdb/adp/phase3_main/query': 'vvv_sgra_survey_response.tbl',
+            'https://archive.eso.org/wdb/wdb/eso/eso_archive_main/query': 'main_sgra_query.tbl',
+            'https://archive.eso.org/wdb/wdb/eso/amber/query': 'amber_sgra_query.tbl',
+            'https://archive.eso.org/wdb/wdb/adp/phase3_main/query': 'vvv_sgra_survey_response.tbl',
         },
     'ADQL':
         {
@@ -211,7 +211,7 @@ def test_tap_url():
     if EsoClass.USE_DEV_TAP:
         assert url == "http://dfidev5.hq.eso.org:8123/tap_obs"
     else:
-        assert url == "http://archive.eso.org/tap_obs"
+        assert url == "https://archive.eso.org/tap_obs"
 
 
 def test_py2adql():

--- a/astroquery/eso/tests/test_eso_remote.py
+++ b/astroquery/eso/tests/test_eso_remote.py
@@ -53,6 +53,44 @@ class TestEso:
         assert len(t) > 0, "Table length is zero"
         assert len(t) == eso.ROW_LIMIT, f"Table length is {lt}, expected {eso.ROW_LIMIT}"
 
+    def test_row_limit(self):
+        eso = Eso()
+        eso.ROW_LIMIT = 5
+        # since in this case the results are truncated, a warning is issued
+
+        with pytest.warns(MaxResultsWarning):
+            table = eso.query_instrument('UVES', cache=False)
+            n = len(table)
+            assert n == eso.ROW_LIMIT, f"Expected {eso.ROW_LIMIT}; Obtained {n}"
+
+        with pytest.warns(MaxResultsWarning):
+            table = eso.query_collections('VVV', cache=False)
+            n = len(table)
+            assert n == eso.ROW_LIMIT, f"Expected {eso.ROW_LIMIT}; Obtained {n}"
+
+        with pytest.warns(MaxResultsWarning):
+            table = eso.query_main(cache=False)
+            n = len(table)
+            assert n == eso.ROW_LIMIT, f"Expected {eso.ROW_LIMIT}; Obtained {n}"
+
+    def test_top(self):
+        eso = Eso()
+        top = 5
+        eso.ROW_LIMIT = None
+        # in this case the results are NOT truncated, no warnings should be issued
+
+        table = eso.query_instrument('UVES', cache=False, top=top)
+        n = len(table)
+        assert n == top, f"Expected {top}; Obtained {n}"
+
+        table = eso.query_collections('VVV', cache=False, top=top)
+        n = len(table)
+        assert n == top, f"Expected {top}; Obtained {n}"
+
+        table = eso.query_main(cache=False, top=top)
+        n = len(table)
+        assert n == top, f"Expected {top}; Obtained {n}"
+
     def test_SgrAstar(self):
         eso = Eso()
         eso.ROW_LIMIT = 1
@@ -286,19 +324,3 @@ class TestEso:
         assert len(result) == 5
         assert 'SGR A' in result['object']
         assert 'SGR A' in result['target']
-
-    def test_top(self):
-        eso = Eso()
-        top = 25
-
-        table = eso.query_instrument('UVES', cache=False, top=top)
-        n = len(table)
-        assert n == top, f"Expected {top}; Obtained {n}"
-
-        table = eso.query_collections('VVV', cache=False, top=top)
-        n = len(table)
-        assert n == top, f"Expected {top}; Obtained {n}"
-
-        table = eso.query_main(cache=False, top=top)
-        n = len(table)
-        assert n == top, f"Expected {top}; Obtained {n}"

--- a/astroquery/eso/tests/test_eso_remote.py
+++ b/astroquery/eso/tests/test_eso_remote.py
@@ -17,7 +17,8 @@ from astroquery.exceptions import NoResultsWarning
 from astroquery.eso import Eso
 
 instrument_list = ['fors1', 'fors2', 'sphere', 'vimos', 'omegacam',
-                   'hawki', 'isaac', 'naco', 'visir', 'vircam', 'apex',
+                   'hawki', 'isaac', 'naco', 'visir', 'vircam',
+                   # TODO 'apex', uncomment when ready in the ISTs
                    'giraffe', 'uves', 'xshooter', 'muse', 'crires',
                    'kmos', 'sinfoni', 'amber', 'midi', 'pionier',
                    'gravity', 'espresso', 'wlgsu', 'matisse', 'eris',
@@ -123,12 +124,14 @@ class TestEso:
 
     def test_SgrAstar_remotevslocal(self, tmp_path):
         eso = Eso()
+        # TODO originally it was 'gravity', but it is not yet ready in the TAP ISTs
+        instrument = 'uves'
         # Remote version
-        result1 = eso.query_instrument('gravity', ra=266.41681662,
+        result1 = eso.query_instrument(instrument, ra=266.41681662,
                                        dec=-29.00782497, radius=1.0, cache=False)
         # Local version
         eso.cache_location = tmp_path
-        result2 = eso.query_instrument('gravity', ra=266.41681662,
+        result2 = eso.query_instrument(instrument, ra=266.41681662,
                                        dec=-29.00782497, radius=1.0, cache=True)
         assert all(result1.values_equal(result2))
 
@@ -136,6 +139,13 @@ class TestEso:
         # If this test fails, we may simply need to update it
 
         inst = set(Eso.list_instruments(cache=False))
+
+        # TODO ############ restore when they are fixed in TAP #
+        try:
+            inst.remove('apex')
+        except ValueError:
+            pass
+        # #################################################### #
 
         # we only care about the sets matching
         assert set(inst) == set(instrument_list), \
@@ -186,6 +196,23 @@ class TestEso:
         eso.cache_location = tmp_path
 
         instruments = eso.list_instruments(cache=False)
+
+        # TODO: restore all of these instruments when they are fixed in the TAP ists ##################################
+        try:
+            instruments.remove('apex')      # ValueError: 1:0: not well-formed (invalid token)
+            #                               # pyvo.dal.exceptions.DALServiceError:
+            #                                 500 Server Error:  for url: http://dfidev5.hq.eso.org:8123/tap_obs/sync
+            instruments.remove('fiat')      # pyvo.dal.exceptions.DALQueryError:
+            #                                 Error converting data type varchar to numeric.
+            instruments.remove('espresso')  # pyvo.dal.exceptions.DALQueryError: Invalid column name 'obs_container_id'
+            instruments.remove('gravity')   # pyvo.dal.exceptions.DALQueryError: Invalid column name 'obs_container_id'
+            instruments.remove('matisse')   # pyvo.dal.exceptions.DALQueryError: Invalid column name 'obs_container_id'
+            instruments.remove('omegacam')  # pyvo.dal.exceptions.DALQueryError: Invalid column name 'obs_container_id'
+            instruments.remove('pionier')   # pyvo.dal.exceptions.DALQueryError: Invalid column name 'obs_container_id'
+            instruments.remove('vircam')    # pyvo.dal.exceptions.DALQueryError: Invalid column name 'obs_container_id'
+        except ValueError:
+            pass
+        # #################################################### #
 
         for instrument in instruments:
             try:
@@ -242,7 +269,7 @@ class TestEso:
         eso.ROW_LIMIT = 5
 
         # the failure should occur here
-        result = eso.query_raw(target='SGR A', object='SGR A')
+        result = eso.query_main(target='SGR A', object='SGR A')
 
         # test that max_results = 5
         assert len(result) == 5

--- a/astroquery/eso/tests/test_eso_remote.py
+++ b/astroquery/eso/tests/test_eso_remote.py
@@ -242,7 +242,7 @@ class TestEso:
         eso.ROW_LIMIT = 5
 
         # the failure should occur here
-        result = eso.query_main(target='SGR A', object='SGR A')
+        result = eso.query_raw(target='SGR A', object='SGR A')
 
         # test that max_results = 5
         assert len(result) == 5

--- a/astroquery/eso/utils.py
+++ b/astroquery/eso/utils.py
@@ -62,7 +62,7 @@ def py2adql(table: str, columns: Union[List, str] = None,
             order_by: str = '', order_by_desc=True, top: int = None):
     """
     Return the adql string corresponding to the parameters passed
-    See adql examples at http://archive.eso.org/tap_obs/examples
+    See adql examples at https://archive.eso.org/tap_obs/examples
     """
     # validate ra, dec, radius
     if not are_coords_valid(ra, dec, radius):

--- a/astroquery/eso/utils.py
+++ b/astroquery/eso/utils.py
@@ -59,18 +59,13 @@ def are_coords_valid(ra: float = None,
 def py2adql(table: str, columns: Union[List, str] = None,
             ra: float = None, dec: float = None, radius: float = None,
             where_constraints: List = None,
-            order_by: str = '', order_by_desc=True, top: int = None):
+            order_by: str = '', order_by_desc=True,
+            count_only: bool = False, top: int = None):
     """
     Return the adql string corresponding to the parameters passed
     See adql examples at https://archive.eso.org/tap_obs/examples
     """
-    # validate ra, dec, radius
-    if not are_coords_valid(ra, dec, radius):
-        message = "Either all three values for (ra, dec, radius) must be present or none of them.\n"
-        message += f"Values provided: ra = {ra:0.7f}, dec = {dec:0.7f}, radius = {radius:0.7f}"
-        raise ValueError(message)
-
-    # coordinates are valid
+    # We assume the coordinates passed are valid
     where_circle = []
     if ra:
         where_circle += [f'intersects(s_region, circle(\'ICRS\', {ra}, {dec}, {radius}))=1']
@@ -83,6 +78,9 @@ def py2adql(table: str, columns: Union[List, str] = None,
         columns = _split_str_as_list_of_str(columns)
     if columns is None or len(columns) < 1:
         columns = ['*']
+    if count_only:
+        columns = ['count(*)']
+
 
     # Build the query
     query_string = ', '.join(columns) + ' from ' + table

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,6 +62,7 @@ filterwarnings =
     ignore:FITS files must be read as binaries:astroquery.exceptions.InputWarning
 # utils.commons.parse_coordinates, we should remove its usage:
     ignore:Coordinate string is being interpreted as an ICRS coordinate:astroquery.exceptions.InputWarning
+    ignore:Partial result set. Potential causes MAXREC, async storage space, etc:pyvo.dal.exceptions.DALOverflowWarning
     ignore:Coordinate string is being interpreted as an ICRS coordinate:UserWarning
 # To be removed with a fix for https://github.com/astropy/astroquery/issues/2242
     ignore::astropy.io.votable.exceptions.E02


### PR DESCRIPTION
 - read the tap_url from env vars if flag USE_TAP_DEV is set
 - rewrite query functions to point to the correct tables
 - clean-up: log functions and http --> https
 - handling of number of records returned: `top` to filter results, `maxrec` to truncate. Warn when results are truncated.