### PR TITLE
Implement columns filter logic

### DIFF
--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -38,7 +38,7 @@ from ..exceptions import RemoteServiceError, LoginError, \
 from ..query import QueryWithLogin
 from ..utils import schema
 from .utils import py2adql, _split_str_as_list_of_str, \
-    adql_sanitize_val, are_coords_valid, reorder_columns, \
+    adql_sanitize_op_val, are_coords_valid, reorder_columns, \
     DEFAULT_LEAD_COLS_PHASE3, DEFAULT_LEAD_COLS_RAW
 
 
@@ -428,7 +428,7 @@ class EsoClass(QueryWithLogin):
             allowed_values = list(map(lambda x: f"'{x.strip()}'", allowed_values))
             where_allowed_vals_strlist = [f"{column_name} in (" + ", ".join(allowed_values) + ")"]
 
-        where_constraints_strlist = [f"{k} {adql_sanitize_val(v)}" for k, v in filters.items()]
+        where_constraints_strlist = [f"{k} {adql_sanitize_op_val(v)}" for k, v in filters.items()]
         where_constraints = where_allowed_vals_strlist + where_constraints_strlist
         query = py2adql(table=table_name, columns=columns,
                         cone_ra=cone_ra, cone_dec=cone_dec, cone_radius=cone_radius,

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -37,8 +37,7 @@ from ..exceptions import RemoteServiceError, LoginError, \
     NoResultsWarning, MaxResultsWarning
 from ..query import QueryWithLogin
 from ..utils import schema
-from .utils import py2adql, _split_str_as_list_of_str, \
-    adql_sanitize_op_val, raise_if_coords_not_valid, reorder_columns, \
+from .utils import raise_if_coords_not_valid, reorder_columns, \
     raise_if_has_deprecated_keys, _build_adql_query, \
     DEFAULT_LEAD_COLS_PHASE3, DEFAULT_LEAD_COLS_RAW
 

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -387,19 +387,20 @@ class EsoClass(QueryWithLogin):
             allowed_values: Union[List[str], str] = None, *,
             cone_ra: float = None, cone_dec: float = None, cone_radius: float = None,
             columns: Union[List, str] = None,
+            column_filters: Optional[Dict[str, str]],
             top: int = None,
             count_only: bool = False,
             query_str_only: bool = False,
             print_help: bool = False,
             authenticated: bool = False,
-            **kwargs) -> Union[astropy.table.Table, int, str]:
+    ) -> Union[astropy.table.Table, int, str]:
         """
         Query instrument- or collection-specific data contained in the ESO archive.
          - instrument-specific data is raw
          - collection-specific data is processed
         """
         columns = columns or []
-        filters = {**dict(kwargs)}
+        filters = column_filters if column_filters else {}
 
         if print_help:
             self._print_table_help(table_name)
@@ -427,7 +428,7 @@ class EsoClass(QueryWithLogin):
             allowed_values = list(map(lambda x: f"'{x.strip()}'", allowed_values))
             where_allowed_vals_strlist = [f"{column_name} in (" + ", ".join(allowed_values) + ")"]
 
-        where_constraints_strlist = [f"{k} = {adql_sanitize_val(v)}" for k, v in filters.items()]
+        where_constraints_strlist = [f"{k} {adql_sanitize_val(v)}" for k, v in filters.items()]
         where_constraints = where_allowed_vals_strlist + where_constraints_strlist
         query = py2adql(table=table_name, columns=columns,
                         cone_ra=cone_ra, cone_dec=cone_dec, cone_radius=cone_radius,
@@ -452,14 +453,14 @@ class EsoClass(QueryWithLogin):
             surveys: Union[List[str], str] = None, *,
             cone_ra: float = None, cone_dec: float = None, cone_radius: float = None,
             columns: Union[List, str] = None,
+            column_filters: Optional[dict] = None,
             top: int = None,
             count_only: bool = False,
             query_str_only: bool = False,
             help: bool = False,
             authenticated: bool = False,
-            column_filters: Optional[dict] = None,
             open_form: bool = False, cache: bool = False,
-            **kwargs) -> Union[astropy.table.Table, int, str]:
+    ) -> Union[astropy.table.Table, int, str]:
         """
         Query survey Phase 3 data contained in the ESO archive.
 
@@ -522,8 +523,7 @@ class EsoClass(QueryWithLogin):
         :rtype: `~astropy.table.Table`, `str`, `int`, or `None`
         """
         _ = open_form, cache  # make explicit that we are aware these arguments are unused
-        c = column_filters if column_filters else {}
-        kwargs = {**kwargs, **c}
+        column_filters = column_filters if column_filters else {}
         t = self._query_on_allowed_values(table_name=EsoNames.phase3_table,
                                           column_name=EsoNames.phase3_surveys_column,
                                           allowed_values=surveys,
@@ -531,12 +531,13 @@ class EsoClass(QueryWithLogin):
                                           cone_dec=cone_dec,
                                           cone_radius=cone_radius,
                                           columns=columns,
+                                          column_filters=column_filters,
                                           top=top,
                                           count_only=count_only,
                                           query_str_only=query_str_only,
                                           print_help=help,
                                           authenticated=authenticated,
-                                          **kwargs)
+                                          )
         t = reorder_columns(t, DEFAULT_LEAD_COLS_PHASE3)
         return t
 
@@ -547,14 +548,14 @@ class EsoClass(QueryWithLogin):
             instruments: Union[List[str], str] = None, *,
             cone_ra: float = None, cone_dec: float = None, cone_radius: float = None,
             columns: Union[List, str] = None,
+            column_filters: Optional[dict] = None,
             top: int = None,
             count_only: bool = False,
             query_str_only: bool = False,
             help: bool = False,
             authenticated: bool = False,
-            column_filters: Optional[dict] = None,
             open_form: bool = False, cache: bool = False,
-            **kwargs) -> Union[astropy.table.Table, int, str]:
+    ) -> Union[astropy.table.Table, int, str]:
         """
         Query raw data from all instruments contained in the ESO archive.
 
@@ -617,8 +618,7 @@ class EsoClass(QueryWithLogin):
         :rtype: `~astropy.table.Table`, `str`, `int`, or `None`
         """
         _ = open_form, cache  # make explicit that we are aware these arguments are unused
-        c = column_filters if column_filters else {}
-        kwargs = {**kwargs, **c}
+        column_filters = column_filters if column_filters else {}
         t = self._query_on_allowed_values(table_name=EsoNames.raw_table,
                                           column_name=EsoNames.raw_instruments_column,
                                           allowed_values=instruments,
@@ -626,12 +626,13 @@ class EsoClass(QueryWithLogin):
                                           cone_dec=cone_dec,
                                           cone_radius=cone_radius,
                                           columns=columns,
+                                          column_filters=column_filters,
                                           top=top,
                                           count_only=count_only,
                                           query_str_only=query_str_only,
                                           print_help=help,
                                           authenticated=authenticated,
-                                          **kwargs)
+                                          )
         t = reorder_columns(t, DEFAULT_LEAD_COLS_RAW)
         return t
 
@@ -642,14 +643,14 @@ class EsoClass(QueryWithLogin):
             instrument: str, *,
             cone_ra: float = None, cone_dec: float = None, cone_radius: float = None,
             columns: Union[List, str] = None,
+            column_filters: Optional[dict] = None,
             top: int = None,
             count_only: bool = False,
             query_str_only: bool = False,
             help: bool = False,
             authenticated: bool = False,
-            column_filters: Optional[dict] = None,
             open_form: bool = False, cache: bool = False,
-            **kwargs) -> Union[astropy.table.Table, int, str]:
+    ) -> Union[astropy.table.Table, int, str]:
         """
         Query instrument-specific raw data contained in the ESO archive.
 
@@ -711,8 +712,7 @@ class EsoClass(QueryWithLogin):
         :rtype: `~astropy.table.Table`, `str`, `int`, or `None`
         """
         _ = open_form, cache  # make explicit that we are aware these arguments are unused
-        c = column_filters if column_filters else {}
-        kwargs = {**kwargs, **c}
+        column_filters = column_filters if column_filters else {}
         t = self._query_on_allowed_values(table_name=EsoNames.ist_table(instrument),
                                           column_name=None,
                                           allowed_values=None,
@@ -720,12 +720,12 @@ class EsoClass(QueryWithLogin):
                                           cone_dec=cone_dec,
                                           cone_radius=cone_radius,
                                           columns=columns,
+                                          column_filters=column_filters,
                                           top=top,
                                           count_only=count_only,
                                           query_str_only=query_str_only,
                                           print_help=help,
-                                          authenticated=authenticated,
-                                          **kwargs)
+                                          authenticated=authenticated)
         t = reorder_columns(t, DEFAULT_LEAD_COLS_RAW)
         return t
 
@@ -1038,14 +1038,14 @@ class EsoClass(QueryWithLogin):
     def query_apex_quicklooks(self,
                               project_id: Union[List[str], str] = None, *,
                               columns: Union[List, str] = None,
+                              column_filters: Optional[dict] = None,
                               top: int = None,
                               count_only: bool = False,
                               query_str_only: bool = False,
                               help: bool = False,
                               authenticated: bool = False,
-                              column_filters: Optional[dict] = None,
                               open_form: bool = False, cache: bool = False,
-                              **kwargs) -> Union[astropy.table.Table, int, str]:
+                              ) -> Union[astropy.table.Table, int, str]:
         """
         APEX data are distributed with quicklook products identified with a
         different name than other ESO products.  This query tool searches by
@@ -1099,19 +1099,18 @@ class EsoClass(QueryWithLogin):
 
         """
         _ = open_form, cache  # make explicit that we are aware these arguments are unused
-        c = column_filters if column_filters else {}
-        kwargs = {**kwargs, **c}
+        column_filters = column_filters if column_filters else {}
         return self._query_on_allowed_values(table_name=EsoNames.apex_quicklooks_table,
                                              column_name=EsoNames.apex_quicklooks_pid_column,
                                              allowed_values=project_id,
                                              cone_ra=None, cone_dec=None, cone_radius=None,
                                              columns=columns,
+                                             column_filters=column_filters,
                                              top=top,
                                              count_only=count_only,
                                              query_str_only=query_str_only,
                                              print_help=help,
-                                             authenticated=authenticated,
-                                             **kwargs)
+                                             authenticated=authenticated)
 
 
 Eso = EsoClass()

--- a/astroquery/eso/tests/test_eso.py
+++ b/astroquery/eso/tests/test_eso.py
@@ -297,7 +297,8 @@ def test_adql_sanitize_val():
     assert adql_sanitize_op_val("< '5'") == "< '5'"
     assert adql_sanitize_op_val("> '1.23'") == "> '1.23'"
     assert adql_sanitize_op_val("like '%John%'") == "like '%John%'"
-    assert adql_sanitize_op_val("in ('apple', 'mango', 'orange')") == "in ('apple', 'mango', 'orange')"
+    assert adql_sanitize_op_val(
+        "in ('apple', 'mango', 'orange')") == "in ('apple', 'mango', 'orange')"
     assert adql_sanitize_op_val("in (1, 2, 3)") == "in (1, 2, 3)"
 
     # These are actual strings, with no operator, so they translate to "= 'some string'"
@@ -309,8 +310,10 @@ def test_adql_sanitize_val():
     # These cases shouldn't be handled.
     # They have an operator, but the adql after the operator is ill formed
     # Let the error be thrown by the query function itself
-    assert adql_sanitize_op_val("like %John%") == "like %John%" # This will raise an exception elsewhere
-    assert adql_sanitize_op_val('= SGR A') == "= SGR A"  # This will raise an exception elsewhere
+    assert adql_sanitize_op_val(
+        "like %John%") == "like %John%"  # This will raise an exception elsewhere
+    assert adql_sanitize_op_val(
+        '= SGR A') == "= SGR A"  # This will raise an exception elsewhere
 
 
 def test_maxrec():

--- a/astroquery/eso/tests/test_eso.py
+++ b/astroquery/eso/tests/test_eso.py
@@ -293,6 +293,13 @@ def test_tap_url():
     ("in ('apple', 'mango', 'orange')", "in ('apple', 'mango', 'orange')"),
     ("in (1, 2, 3)", "in (1, 2, 3)"),
 
+    # Operator-based queries
+    ("<5", "< 5"),
+    (">1.23", "> 1.23"),
+    ("<'5'", "< '5'"),
+    (">'1.23'", "> '1.23'"),
+    ("like'%John%'", "like '%John%'"),
+
     # Strings that look like operators but should be treated as strings
     ("'like %John%'", "= 'like %John%'"),
     ("'= something'", "= '= something'"),

--- a/astroquery/eso/tests/test_eso.py
+++ b/astroquery/eso/tests/test_eso.py
@@ -486,7 +486,7 @@ def test_reorder_columns(monkeypatch):
                 "dataproduct_type": "in ('spectrum')"
             },
             top=100,
-            order_by="signal_to_noise",
+            order_by="em_min",
             order_by_desc=True,
             count_only=False,
             query_str_only=True,
@@ -494,7 +494,7 @@ def test_reorder_columns(monkeypatch):
         "select top 100 target_name, s_ra, s_dec, em_min, em_max from ivoa.ObsCore "
         "where em_min > 4e-7 and em_max < 1.2e-6 and dataproduct_type in ('spectrum') "
         "and intersects(s_region, circle('ICRS', 180.0, -45.0, 0.05))=1 "
-        "order by signal_to_noise desc"
+        "order by em_min desc"
     ),
 
     # With all params 2
@@ -511,15 +511,14 @@ def test_reorder_columns(monkeypatch):
                 "dataproduct_type": "in ('spectrum')"
             },
             top=100,
-            order_by="signal_to_noise",
+            order_by="em_min",
             order_by_desc=False,
             count_only=True,
             query_str_only=True,
         ),
         "select top 100 count(*) from ivoa.ObsCore "
         "where em_min > 4e-7 and em_max < 1.2e-6 and dataproduct_type in ('spectrum') "
-        "and intersects(s_region, circle('ICRS', 180.0, -45.0, 0.05))=1 "
-        "order by signal_to_noise asc"
+        "and intersects(s_region, circle('ICRS', 180.0, -45.0, 0.05))=1"
     ),
 ])
 def test_py2adql(params, expected):

--- a/astroquery/eso/tests/test_eso.py
+++ b/astroquery/eso/tests/test_eso.py
@@ -45,8 +45,6 @@ DATA_FILES = {
         },
     'ADQL':
         {
-            # TODO: Point the second query to an IST when the ISTs are available.
-            # TODO: Fix the apex query when the backend is available.
             "select * from ivoa.ObsCore where obs_collection in ('VVV') and "
             "intersects(s_region, circle('ICRS', 266.41681662, -29.00782497, 0.1775))=1":
             "query_coll_vvv_sgra.pickle",
@@ -61,8 +59,6 @@ DATA_FILES = {
 
             "select table_name from TAP_SCHEMA.tables where schema_name='ist' order by table_name":
             "query_list_instruments.pickle",
-
-            "APEX_QUERY_PLACEHOLDER": "query_apex_ql_5.pickle",
 
             "generic cached query":
             "fd303fa27993048bd2393af067fe5ceccf4817c288ce5c0b4343386f.pickle",
@@ -440,7 +436,8 @@ def test_reorder_columns(monkeypatch):
         table_name="galaxies",
         columns="name, ra, dec",
         cone_ra=150.1, cone_dec=2.3, cone_radius=0.1),
-     "select name, ra, dec from galaxies where intersects(s_region, circle('ICRS', 150.1, 2.3, 0.1))=1"),
+     "select name, ra, dec from galaxies where "
+     "intersects(s_region, circle('ICRS', 150.1, 2.3, 0.1))=1"),
 
     # With count_only
     (_UserParams(
@@ -464,7 +461,8 @@ def test_reorder_columns(monkeypatch):
         columns=["id", "instrument"],
         column_filters={"instrument": "in ('MUSE', 'UVES')", "t_exptime": "> 100"},
         order_by="t_exptime"),
-     "select id, instrument from beautiful.Stars where instrument in ('MUSE', 'UVES') and t_exptime > 100 order by t_exptime desc"),
+     "select id, instrument from beautiful.Stars where instrument in ('MUSE', 'UVES') "
+     "and t_exptime > 100 order by t_exptime desc"),
 
     # With all params 1
     (

--- a/astroquery/eso/tests/test_eso.py
+++ b/astroquery/eso/tests/test_eso.py
@@ -126,7 +126,7 @@ def test_sinfoni_sgr_a_star(monkeypatch):
     monkeypatch.setattr(eso, 'query_tap_service', monkey_tap)
     result = eso.query_instrument('sinfoni',
                                   column_filters={
-                                      'target': "= 'SGRA'"
+                                      'target': "SGRA"
                                   }
                                   )
     # test all results are there and the expected target is present
@@ -140,8 +140,8 @@ def test_main_sgr_a_star(monkeypatch):
     monkeypatch.setattr(eso, 'query_tap_service', monkey_tap)
     result = eso.query_main(
         column_filters={
-            'target': "= 'SGR A'",
-            'object': "= 'SGR A'"
+            'target': "SGR A",
+            'object': "SGR A"
         })
     # test all results are there and the expected target is present
     assert len(result) == 23
@@ -290,6 +290,7 @@ def test_adql_sanitize_val():
     assert adql_sanitize_op_val("1.5 ") == "= '1.5'"
     assert adql_sanitize_op_val(" a string with spaces ") == "= 'a string with spaces'"
     assert adql_sanitize_op_val("SGR A") == "= 'SGR A'"
+    assert adql_sanitize_op_val("'SGR A'") == "= 'SGR A'"
 
     assert adql_sanitize_op_val("< 5") == "< 5"
     assert adql_sanitize_op_val("> 1.23") == "> 1.23"
@@ -375,8 +376,8 @@ def test_reorder_columns(monkeypatch):
     monkeypatch.setattr(eso, 'query_tap_service', monkey_tap)
     table = eso.query_main(
         column_filters={
-            'target': "= 'SGR A'",
-            'object': "= 'SGR A'"}
+            'target': "SGR A",
+            'object': "SGR A"}
     )
     names_before = table.colnames[:]
     table2 = reorder_columns(table)

--- a/astroquery/eso/tests/test_eso.py
+++ b/astroquery/eso/tests/test_eso.py
@@ -18,7 +18,8 @@ from astropy.table import Table
 
 from astroquery.utils.mocks import MockResponse
 from ...eso import Eso
-from ...eso.utils import py2adql, adql_sanitize_op_val, reorder_columns, \
+from ...eso.utils import _UserParams, \
+    _py2adql, _adql_sanitize_op_val, reorder_columns, \
     DEFAULT_LEAD_COLS_RAW
 from ...exceptions import NoResultsWarning, MaxResultsWarning
 
@@ -278,41 +279,41 @@ def test_adql_sanitize_val():
     # select [...] where x_int = 9
     # select [...] where x_str = '9'
 
-    assert adql_sanitize_op_val(1) == "= 1"
-    assert adql_sanitize_op_val(1.5) == "= 1.5"
-    assert adql_sanitize_op_val(None) == "= None"
+    assert _adql_sanitize_op_val(1) == "= 1"
+    assert _adql_sanitize_op_val(1.5) == "= 1.5"
+    assert _adql_sanitize_op_val(None) == "= None"
 
-    assert adql_sanitize_op_val("ciao") == "= 'ciao'"
-    assert adql_sanitize_op_val("1.5") == "= '1.5'"
-    assert adql_sanitize_op_val("ciao  ") == "= 'ciao'"
-    assert adql_sanitize_op_val("  ciao") == "= 'ciao'"
-    assert adql_sanitize_op_val("  ciao  ") == "= 'ciao'"
-    assert adql_sanitize_op_val("1.5 ") == "= '1.5'"
-    assert adql_sanitize_op_val(" a string with spaces ") == "= 'a string with spaces'"
-    assert adql_sanitize_op_val("SGR A") == "= 'SGR A'"
-    assert adql_sanitize_op_val("'SGR A'") == "= 'SGR A'"
+    assert _adql_sanitize_op_val("ciao") == "= 'ciao'"
+    assert _adql_sanitize_op_val("1.5") == "= '1.5'"
+    assert _adql_sanitize_op_val("ciao  ") == "= 'ciao'"
+    assert _adql_sanitize_op_val("  ciao") == "= 'ciao'"
+    assert _adql_sanitize_op_val("  ciao  ") == "= 'ciao'"
+    assert _adql_sanitize_op_val("1.5 ") == "= '1.5'"
+    assert _adql_sanitize_op_val(" a string with spaces ") == "= 'a string with spaces'"
+    assert _adql_sanitize_op_val("SGR A") == "= 'SGR A'"
+    assert _adql_sanitize_op_val("'SGR A'") == "= 'SGR A'"
 
-    assert adql_sanitize_op_val("< 5") == "< 5"
-    assert adql_sanitize_op_val("> 1.23") == "> 1.23"
-    assert adql_sanitize_op_val("< '5'") == "< '5'"
-    assert adql_sanitize_op_val("> '1.23'") == "> '1.23'"
-    assert adql_sanitize_op_val("like '%John%'") == "like '%John%'"
-    assert adql_sanitize_op_val(
+    assert _adql_sanitize_op_val("< 5") == "< 5"
+    assert _adql_sanitize_op_val("> 1.23") == "> 1.23"
+    assert _adql_sanitize_op_val("< '5'") == "< '5'"
+    assert _adql_sanitize_op_val("> '1.23'") == "> '1.23'"
+    assert _adql_sanitize_op_val("like '%John%'") == "like '%John%'"
+    assert _adql_sanitize_op_val(
         "in ('apple', 'mango', 'orange')") == "in ('apple', 'mango', 'orange')"
-    assert adql_sanitize_op_val("in (1, 2, 3)") == "in (1, 2, 3)"
+    assert _adql_sanitize_op_val("in (1, 2, 3)") == "in (1, 2, 3)"
 
     # These are actual strings, with no operator, so they translate to "= 'some string'"
-    assert adql_sanitize_op_val("'like %John%'") == "= 'like %John%'"
-    assert adql_sanitize_op_val("'= something'") == "= '= something'"
-    assert adql_sanitize_op_val("'> 5'") == "= '> 5'"
-    assert adql_sanitize_op_val("' > 1.23 '") == "= ' > 1.23 '"
+    assert _adql_sanitize_op_val("'like %John%'") == "= 'like %John%'"
+    assert _adql_sanitize_op_val("'= something'") == "= '= something'"
+    assert _adql_sanitize_op_val("'> 5'") == "= '> 5'"
+    assert _adql_sanitize_op_val("' > 1.23 '") == "= ' > 1.23 '"
 
     # These cases shouldn't be handled.
     # They have an operator, but the adql after the operator is ill formed
     # Let the error be thrown by the query function itself
-    assert adql_sanitize_op_val(
+    assert _adql_sanitize_op_val(
         "like %John%") == "like %John%"  # This will raise an exception elsewhere
-    assert adql_sanitize_op_val(
+    assert _adql_sanitize_op_val(
         '= SGR A') == "= SGR A"  # This will raise an exception elsewhere
 
 
@@ -414,7 +415,114 @@ def test_reorder_columns(monkeypatch):
     assert not_a_table_1 == not_a_table_2
 
 
-def test_py2adql():
+@pytest.mark.parametrize("params, expected", [
+    # Basic SELECT * cases
+    (_UserParams(table_name="ivoa.ObsCore"),
+     "select * from ivoa.ObsCore"),
+
+    (_UserParams(table_name="ivoa.ObsCore", columns=''),
+     "select * from ivoa.ObsCore"),
+
+    (_UserParams(table_name="ivoa.ObsCore", columns='*'),
+     "select * from ivoa.ObsCore"),
+
+    # Basic column selection
+    (_UserParams(table_name="my.Table", columns="a, b, c"),
+     "select a, b, c from my.Table"),
+
+    (_UserParams(table_name="my.Table", columns=["a", "b", "c"]),
+     "select a, b, c from my.Table"),
+
+    # With filters and order
+    (_UserParams(
+        table_name="my.Table",
+        columns=["a", "b", "c"],
+        column_filters={"x": "> 1", "y": "< 2"},
+        order_by="z"),
+     "select a, b, c from my.Table where x > 1 and y < 2 order by z desc"),
+
+    # With cone search
+    (_UserParams(
+        table_name="galaxies",
+        columns="name, ra, dec",
+        cone_ra=150.1, cone_dec=2.3, cone_radius=0.1),
+     "select name, ra, dec from galaxies where intersects(s_region, circle('ICRS', 150.1, 2.3, 0.1))=1"),
+
+    # With count_only
+    (_UserParams(
+        table_name="galaxies",
+        cone_ra=10, cone_dec=20, cone_radius=0.5,
+        count_only=True),
+     "select count(*) from galaxies where intersects(s_region, circle('ICRS', 10, 20, 0.5))=1"),
+
+    # With top
+    (_UserParams(
+        table_name="stars",
+        columns="name, mag",
+        top=10,
+        order_by="mag",
+        order_by_desc=False),
+     "select top 10 name, mag from stars order by mag asc"),
+
+    # With multiple filters including IN
+    (_UserParams(
+        table_name="beautiful.Stars",
+        columns=["id", "instrument"],
+        column_filters={"instrument": "in ('MUSE', 'UVES')", "t_exptime": "> 100"},
+        order_by="t_exptime"),
+     "select id, instrument from beautiful.Stars where instrument in ('MUSE', 'UVES') and t_exptime > 100 order by t_exptime desc"),
+
+    # With all params 1
+    (
+        _UserParams(
+            table_name="ivoa.ObsCore",
+            cone_ra=180.0,
+            cone_dec=-45.0,
+            cone_radius=0.05,
+            columns=["target_name", "s_ra", "s_dec", "em_min", "em_max"],
+            column_filters={
+                "em_min": "> 4e-7",
+                "em_max": "< 1.2e-6",
+                "dataproduct_type": "in ('spectrum')"
+            },
+            top=100,
+            order_by="signal_to_noise",
+            order_by_desc=True,
+            count_only=False,
+            query_str_only=True,
+        ),
+        "select top 100 target_name, s_ra, s_dec, em_min, em_max from ivoa.ObsCore "
+        "where em_min > 4e-7 and em_max < 1.2e-6 and dataproduct_type in ('spectrum') "
+        "and intersects(s_region, circle('ICRS', 180.0, -45.0, 0.05))=1 "
+        "order by signal_to_noise desc"
+    ),
+
+    # With all params 2
+    (
+        _UserParams(
+            table_name="ivoa.ObsCore",
+            cone_ra=180.0,
+            cone_dec=-45.0,
+            cone_radius=0.05,
+            columns=["target_name", "s_ra", "s_dec", "em_min", "em_max"],
+            column_filters={
+                "em_min": "> 4e-7",
+                "em_max": "< 1.2e-6",
+                "dataproduct_type": "in ('spectrum')"
+            },
+            top=100,
+            order_by="signal_to_noise",
+            order_by_desc=False,
+            count_only=True,
+            query_str_only=True,
+        ),
+        "select top 100 count(*) from ivoa.ObsCore "
+        "where em_min > 4e-7 and em_max < 1.2e-6 and dataproduct_type in ('spectrum') "
+        "and intersects(s_region, circle('ICRS', 180.0, -45.0, 0.05))=1 "
+        "order by signal_to_noise asc"
+    ),
+])
+def test_py2adql(params, expected):
     """
     #  Example query:
     #
@@ -434,120 +542,5 @@ def test_py2adql():
     #      em_max<1.2e-6
     #  ORDER BY SNR DESC
     """
-
-    # Simple tests
-    q = py2adql('ivoa.ObsCore')
-    eq = "select * from ivoa.ObsCore"
-    assert eq == q, f"Expected:\n{eq}\n\nObtained:\n{q}\n\n"
-
-    q = py2adql('ivoa.ObsCore', columns='')
-    eq = "select * from ivoa.ObsCore"
-    assert eq == q, f"Expected:\n{eq}\n\nObtained:\n{q}\n\n"
-
-    q = py2adql('ivoa.ObsCore', columns='*')
-    eq = "select * from ivoa.ObsCore"
-    assert eq == q, f"Expected:\n{eq}\n\nObtained:\n{q}\n\n"
-
-    q = py2adql('pinko.Pallino', ['pippo', 'tizio', 'caio'])
-    eq = "select pippo, tizio, caio from pinko.Pallino"
-    assert eq == q, f"Expected:\n{eq}\n\nObtained:\n{q}\n\n"
-
-    q = py2adql('pinko.Pallino', ['pippo', 'tizio', 'caio'])
-    eq = "select pippo, tizio, caio from pinko.Pallino"
-    assert eq == q, f"Expected:\n{eq}\n\nObtained:\n{q}\n\n"
-
-    q = py2adql('pinko.Pallino', ['pippo', 'tizio', 'caio'],
-                where_constraints=['asdf > 1', 'asdf < 2', 'asdf = 3', 'asdf != 4'],
-                order_by='order_col')
-    eq = "select pippo, tizio, caio from pinko.Pallino " + \
-        "where asdf > 1 and asdf < 2 and asdf = 3 and asdf != 4 " + \
-        "order by order_col desc"
-    assert eq == q, f"Expected:\n{eq}\n\nObtained:\n{q}\n\n"
-
-    q = py2adql('pinko.Pallino', ['pippo', 'tizio', 'caio'],
-                where_constraints=["asdf = 'ASDF'", "bcd = 'BCD'"],
-                order_by='order_col')
-    eq = "select pippo, tizio, caio from pinko.Pallino " + \
-        "where asdf = 'ASDF' and bcd = 'BCD' " + \
-        "order by order_col desc"
-    assert eq == q, f"Expected:\n{eq}\n\nObtained:\n{q}\n\n"
-
-    # All arguments
-    columns = 'target_name, dp_id, s_ra, s_dec, t_exptime, em_min, em_max, ' + \
-        'dataproduct_type, instrument_name, obstech, abmaglim, ' + \
-        'proposal_id, obs_collection'
-    table = 'ivoa.ObsCore'
-    and_c_list = ['em_min>4.0e-7', 'em_max<1.2e-6', 'asdasdads']
-
-    q = py2adql(columns=columns, table=table,
-                where_constraints=and_c_list,
-                order_by='snr', order_by_desc=True)
-    expected_query = 'select ' + columns + ' from ' + table + \
-        ' where ' + and_c_list[0] + ' and ' + and_c_list[1] + ' and ' + and_c_list[2] + \
-        " order by snr desc"
-    assert expected_query == q, f"Expected:\n{expected_query}\n\nObtained:\n{q}\n\n"
-
-    # All arguments
-    q = py2adql(columns=columns, table=table,
-                where_constraints=and_c_list,
-                order_by='snr', order_by_desc=False)
-    expected_query = 'select ' + columns + ' from ' + table + \
-        ' where ' + and_c_list[0] + ' and ' + and_c_list[1] + ' and ' + and_c_list[2] + \
-        " order by snr asc"
-    assert expected_query == q, f"Expected:\n{expected_query}\n\nObtained:\n{q}\n\n"
-
-    # ra, dec, radius, all int
-    q = py2adql(columns=columns, table=table,
-                where_constraints=and_c_list,
-                order_by='snr', order_by_desc=False,
-                cone_ra=1, cone_dec=2, cone_radius=3)
-    expected_query = 'select ' + columns + ' from ' + table + \
-        ' where ' + and_c_list[0] + ' and ' + and_c_list[1] + ' and ' + and_c_list[2] + \
-        ' and intersects(s_region, circle(\'ICRS\', 1, 2, 3))=1' + \
-        " order by snr asc"
-    assert expected_query == q, f"Expected:\n{expected_query}\n\nObtained:\n{q}\n\n"
-
-    # ra, dec, radius, all float
-    q = py2adql(columns=columns, table=table,
-                where_constraints=and_c_list,
-                order_by='snr', order_by_desc=False,
-                cone_ra=1.23, cone_dec=2.34, cone_radius=3.45)
-    expected_query = 'select ' + columns + ' from ' + table + \
-        ' where ' + and_c_list[0] + ' and ' + and_c_list[1] + ' and ' + and_c_list[2] + \
-        ' and intersects(s_region, circle(\'ICRS\', 1.23, 2.34, 3.45))=1' + \
-        " order by snr asc"
-    assert expected_query == q, f"Expected:\n{expected_query}\n\nObtained:\n{q}\n\n"
-
-    # ra, dec, radius, all zero
-    q = py2adql(columns=columns, table=table,
-                where_constraints=and_c_list,
-                order_by='snr', order_by_desc=False,
-                cone_ra=0, cone_dec=0, cone_radius=0)
-    expected_query = 'select ' + columns + ' from ' + table + \
-        ' where ' + and_c_list[0] + ' and ' + and_c_list[1] + ' and ' + and_c_list[2] + \
-        ' and intersects(s_region, circle(\'ICRS\', 0, 0, 0))=1' + \
-        " order by snr asc"
-    assert expected_query == q, f"Expected:\n{expected_query}\n\nObtained:\n{q}\n\n"
-
-    # count only
-    q = py2adql(columns=columns, table=table,
-                where_constraints=and_c_list,
-                order_by='snr', order_by_desc=False,
-                cone_ra=1.23, cone_dec=2.34, cone_radius=3.45, count_only=True)
-    expected_query = ("select count(*) from ivoa.ObsCore where "
-                      "em_min>4.0e-7 and em_max<1.2e-6 and asdasdads "
-                      "and intersects(s_region, circle('ICRS', 1.23, 2.34, 3.45))=1 "
-                      "order by snr asc")
-    assert expected_query == q, f"Expected:\n{expected_query}\n\nObtained:\n{q}\n\n"
-
-    # top
-    q = py2adql(columns=columns, table=table,
-                where_constraints=and_c_list,
-                order_by='snr', order_by_desc=False,
-                cone_ra=1.23, cone_dec=2.34, cone_radius=3.45, top=5)
-    expected_query = 'select top 5 ' + columns + ' from ' + table + \
-        ' where ' + and_c_list[0] + ' and ' + and_c_list[1] + ' and ' + and_c_list[2] + \
-        ' and intersects(s_region, circle(\'ICRS\', 1.23, 2.34, 3.45))=1' + \
-        " order by snr asc"
-
-    assert expected_query == q, f"Expected:\n{expected_query}\n\nObtained:\n{q}\n\n"
+    query = _py2adql(params)
+    assert query == expected, f"Expected:\n{expected}\n\nGot:\n{query}\n"

--- a/astroquery/eso/tests/test_eso_remote.py
+++ b/astroquery/eso/tests/test_eso_remote.py
@@ -172,11 +172,12 @@ class TestEso:
     def test_sgrastar_column_filters(self):
         eso = Eso()
 
-        result1 = eso.query_surveys(["sphere", "vegas"],
+        result1 = eso.query_surveys("sphere, vegas",
                                     columns=("obs_collection, calib_level, "
-                                    "multi_ob, filter, s_pixel_scale, instrument_name"),
-                                    calib_level=3,
-                                    multi_ob='M'
+                                             "multi_ob, filter, s_pixel_scale, instrument_name"),
+                                    column_filters={
+                                        'calib_level': "= 3",
+                                        'multi_ob': "like 'M'"}
                                     )
 
         result2 = eso.query_surveys("sphere, vegas",
@@ -227,8 +228,16 @@ class TestEso:
     def test_apex_retrieval(self):
         eso = Eso()
 
-        tblb = eso.query_apex_quicklooks(project_id='E-095.F-9802A-2015')
-        tbla = eso.query_apex_quicklooks(prog_id='095.F-9802(A)')
+        tblb = eso.query_apex_quicklooks(
+            column_filters={
+                "project_id": 'E-095.F-9802A-2015'
+            }
+        )
+        tbla = eso.query_apex_quicklooks(
+            column_filters={
+                "prog_id": '095.F-9802(A)'
+            }
+        )
 
         assert len(tbla) == 5
         assert set(tbla['release_date']) == {
@@ -307,7 +316,11 @@ class TestEso:
         eso.maxrec = 5
 
         with pytest.warns(MaxResultsWarning):
-            result = eso.query_main(target='SGR A', object='SGR A')
+            result = eso.query_main(
+                column_filters={
+                    'target': "= 'SGR A'",
+                    'object': "= 'SGR A'"}
+            )
 
         assert len(result) == 5
         assert 'SGR A' in result['object']

--- a/astroquery/eso/tests/test_eso_remote.py
+++ b/astroquery/eso/tests/test_eso_remote.py
@@ -177,7 +177,7 @@ class TestEso:
                                              "multi_ob, filter, s_pixel_scale, instrument_name"),
                                     column_filters={
                                         'calib_level': "= 3",
-                                        'multi_ob': "like 'M'"}
+                                        'multi_ob': "like '%M%'"}
                                     )
 
         result2 = eso.query_surveys("sphere, vegas",
@@ -318,8 +318,8 @@ class TestEso:
         with pytest.warns(MaxResultsWarning):
             result = eso.query_main(
                 column_filters={
-                    'target': "= 'SGR A'",
-                    'object': "= 'SGR A'"}
+                    'target': "SGR A",
+                    'object': "SGR A"}
             )
 
         assert len(result) == 5

--- a/astroquery/eso/utils.py
+++ b/astroquery/eso/utils.py
@@ -30,7 +30,7 @@ def raise_if_has_deprecated_keys(filters: Optional[Dict[str, str]]) -> bool:
     if any(k in filters for k in {"etime", "stime"}):
         raise ValueError(
             "'stime' and 'etime' are deprecated; "
-            "use instead 'exp_time' together with '<', '>', 'between'. Examples:"
+            "use instead 'exp_time' together with '<', '>', 'between'. Examples:\n"
             "\tcolumn_filters = {'exp_time': '< 2024-01-01'}\n"
             "\tcolumn_filters = {'exp_time': '>= 2023-01-01'}\n"
             "\tcolumn_filters = {'exp_time': between '2023-01-01' and '2024-01-01'}\n"

--- a/astroquery/eso/utils.py
+++ b/astroquery/eso/utils.py
@@ -184,7 +184,7 @@ def _py2adql(user_params: _UserParams) -> str:
         where_string = ' where ' + ' and '.join(wc)
         query_string += where_string
 
-    if len(up.order_by) > 0:
+    if len(up.order_by) > 0 and not up.count_only:
         order_string = ' order by ' + up.order_by + (' desc ' if up.order_by_desc else ' asc ')
         query_string += order_string
 

--- a/astroquery/eso/utils.py
+++ b/astroquery/eso/utils.py
@@ -24,15 +24,15 @@ def raise_if_has_deprecated_keys(filters: Optional[Dict[str, str]]) -> bool:
     if any(k in filters for k in {"box", "coord1", "coord2"}):
         raise ValueError(
             "box, coord1 and coord2 are deprecated; "
-            "use cone_ra, cone_dec and cone_radius instead"
+            "use cone_ra, cone_dec and cone_radius instead."
         )
 
     if any(k in filters for k in {"etime", "stime"}):
         raise ValueError(
-            "stime and etime are deprecated; "
-            "use instead exp_time, together with '<', '>', 'between'. Examples:"
+            "'stime' and 'etime' are deprecated; "
+            "use instead 'exp_time' together with '<', '>', 'between'. Examples:"
             "\tcolumn_filters = {'exp_time': '< 2024-01-01'}\n"
-            "\tcolumn_filters = {'exp_time': '> 2023-01-01'}\n"
+            "\tcolumn_filters = {'exp_time': '>= 2023-01-01'}\n"
             "\tcolumn_filters = {'exp_time': between '2023-01-01' and '2024-01-01'}\n"
         )
 

--- a/astroquery/eso/utils.py
+++ b/astroquery/eso/utils.py
@@ -31,10 +31,10 @@ def raise_if_has_deprecated_keys(filters: Optional[Dict[str, str]]) -> bool:
         raise ValueError(
             "stime and etime are deprecated; "
             "use instead exp_time, together with '<', '>', 'between'\n"
-            "Examples:\n"
-            "\t column_filters = {'exp_time': '< 2024-01-01'}"
-            "\t column_filters = {'exp_time': '> 2023-01-01'}"
-            "\t column_filters = {'exp_time': between '2023-01-01' and '2024-01-01'}"
+            "\tExamples:\n"
+            "\t\tcolumn_filters = {'exp_time': '< 2024-01-01'}\n"
+            "\t\tcolumn_filters = {'exp_time': '> 2023-01-01'}\n"
+            "\t\tcolumn_filters = {'exp_time': between '2023-01-01' and '2024-01-01'}\n"
         )
 
 

--- a/astroquery/eso/utils.py
+++ b/astroquery/eso/utils.py
@@ -39,17 +39,17 @@ def _split_str_as_list_of_str(column_str: str):
     return column_list
 
 
-def raise_if_has_deprecated_keys(filters: Optional[Dict[str, str]]) -> bool:
+def _raise_if_has_deprecated_keys(filters: Optional[Dict[str, str]]) -> bool:
     if not filters:
         return
 
-    if any(k in filters for k in {"box", "coord1", "coord2"}):
+    if any(k in filters for k in ("box", "coord1", "coord2")):
         raise ValueError(
             "box, coord1 and coord2 are deprecated; "
             "use cone_ra, cone_dec and cone_radius instead."
         )
 
-    if any(k in filters for k in {"etime", "stime"}):
+    if any(k in filters for k in ("etime", "stime")):
         raise ValueError(
             "'stime' and 'etime' are deprecated; "
             "use instead 'exp_time' together with '<', '>', 'between'. Examples:\n"

--- a/astroquery/eso/utils.py
+++ b/astroquery/eso/utils.py
@@ -122,6 +122,12 @@ def _adql_sanitize_op_val(op_val):
     op_val = op_val.strip()
     parts = op_val.split(" ", 1)
 
+    if len(parts) == 1:
+        for s in supported_operators:
+            if op_val.startswith(s):
+                operator, value = s, op_val.split(s, 1)[-1]
+                return f"{operator} {value}"
+
     if len(parts) == 2 and parts[0].lower() in supported_operators:
         operator, value = parts
         return f"{operator} {value}"

--- a/astroquery/eso/utils.py
+++ b/astroquery/eso/utils.py
@@ -30,11 +30,10 @@ def raise_if_has_deprecated_keys(filters: Optional[Dict[str, str]]) -> bool:
     if any(k in filters for k in {"etime", "stime"}):
         raise ValueError(
             "stime and etime are deprecated; "
-            "use instead exp_time, together with '<', '>', 'between'\n"
-            "\tExamples:\n"
-            "\t\tcolumn_filters = {'exp_time': '< 2024-01-01'}\n"
-            "\t\tcolumn_filters = {'exp_time': '> 2023-01-01'}\n"
-            "\t\tcolumn_filters = {'exp_time': between '2023-01-01' and '2024-01-01'}\n"
+            "use instead exp_time, together with '<', '>', 'between'. Examples:"
+            "\tcolumn_filters = {'exp_time': '< 2024-01-01'}\n"
+            "\tcolumn_filters = {'exp_time': '> 2023-01-01'}\n"
+            "\tcolumn_filters = {'exp_time': between '2023-01-01' and '2024-01-01'}\n"
         )
 
 

--- a/astroquery/eso/utils.py
+++ b/astroquery/eso/utils.py
@@ -41,11 +41,35 @@ def reorder_columns(table: Table,
     return table
 
 
-def adql_sanitize_val(x):
+def adql_sanitize_val(v):
     """
-    If the value is a string, put it into single quotes
+    Expected values for v are:
+    "= 5",
+    "< 3.14",
+    "like '%John Doe%'"
+    "in ('item1', 'item2', 'item3')
+
+    So the logic is:
+    "<operator> SPACE <value>"
+
+    If no SPACE, assume the <operator> to be "="
     """
-    retval = f"'{x}'" if isinstance(x, str) else f"{x}"
+    operator = "="
+    value = None
+
+    if not isinstance(v, str):
+        operator = "="
+        value = f"{v}"
+    else:
+        # v is a string - can it be split?
+        o_v = v.split(" ", 1)
+        operator, value = ["=", f"'{o_v[0]}'"] if len(o_v) < 2 else o_v
+        # try:
+        # except ValueError as e:
+        #    raise ValueError("Perhaps you missed the ADQL operator in the filter string?"
+        #                     f"Filter string provided: {v}") from e
+
+    retval = f"{operator} {value}"
     return retval
 
 


### PR DESCRIPTION
The logic implemented for the `filter_columns` argument is as follows: 

`column_filters={"<col_name>": "<operator> <SPACE> <value>"}`

For example:

`column_filters={"ra": "< 10.0", "pi_coi": "like "%Juan%", ""}`

or

`column_filters={"target": "'IX Vel'", "date_obs": "between '2020-01-01' and '2025-12-31'", "dp_cat"="SCIENCE")`